### PR TITLE
fix: `https`

### DIFF
--- a/prompthub/prompt.py
+++ b/prompthub/prompt.py
@@ -7,7 +7,7 @@ import yaml
 import requests
 
 
-MAIN_ENDPOINT = os.getenv("PROMPTHUB_MAIN_ENDPOINT", "http://api.prompthub.deepset.ai")
+MAIN_ENDPOINT = os.getenv("PROMPTHUB_MAIN_ENDPOINT", "https://api.prompthub.deepset.ai")
 
 
 @dataclass


### PR DESCRIPTION
Use of `https` seems to have become mandatory in order to reach the hub. This PR fixes the integration.